### PR TITLE
Enable Slack notification for Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,6 @@ pipeline:
       - npm install gulp-cli -g
       - npm install
       - npm run init
-    secrets: []
     when:
       event: [push, tag]
 
@@ -49,6 +48,9 @@ pipeline:
     image: plugins/slack
     channel: drone-ci
     username: Drone-CI
-    secrets: [SLACK_WEBHOOK]
+    webhook:
+      from_secret: SLACK_WEBHOOK
     when:
+      event: [push, tag]
+      branch: [master]
       status: [failure]


### PR DESCRIPTION
## Purpose
We need to know when a build of `master` branch fails, so we need to enable the Slack notification.